### PR TITLE
Add icon display setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Optionally, tag it with a version:
   * `hideInput`: **(optional)** Defines whether to hide or not the `code` input parameter. Defaults to `True`.
   * `isAdvancedMode`: **(optional)** Defines whether the script is in advanced mode (aka GH_Component SDK mode) or procedural mode. Defaults to `False`.
   * `marshalOutGuids`: **(optional)** Defines whether output Guids will be looked up or not. Defaults to `True`. Change to `False` to preserve output Guids.
+  * `iconDisplay`: **(optional)** Defines whether to display the icon or not. Defaults to `0`.
+    * `0` : Application setting
+    * `1` : Text display
+    * `2` : Icon display
   * `inputParameters`: List of input parameters.
     * `name`: Name of the input parameter.
     * `nickname`: **(optional)** Abbreviation of the input parameter. Defaults to the same as `name`.

--- a/componentize.py
+++ b/componentize.py
@@ -193,11 +193,12 @@ def create_ghuser_component(source, target, version=None):
     ghpython_root.SetBoolean('HideOutput', ghpython_data.get('hideOutput', True))
     ghpython_root.SetBoolean('HideInput', ghpython_data.get('hideInput', True))
     ghpython_root.SetBoolean('IsAdvancedMode', ghpython_data.get('isAdvancedMode', False))
+    ghpython_root.SetInt32('IconDisplay', ghpython_data.get('iconDisplay', 0))
     ghpython_root.SetString('Name', data['name'])
     ghpython_root.SetString('NickName', data['nickname'])
     ghpython_root.SetBoolean('MarshalOutGuids', ghpython_data.get('marshalOutGuids', True))
     ghpython_root.SetString('CodeInput', code)
-
+    
     # ghpython_root.CreateChunk('Attributes')
     # for mf in ('Bounds', 'Pivot', 'Selected'):
     params = ghpython_root.CreateChunk('ParameterData')

--- a/examples/Test_KitchenSink/metadata.json
+++ b/examples/Test_KitchenSink/metadata.json
@@ -12,6 +12,7 @@
         "hideInput": true,
         "isAdvancedMode": true,
         "marshalOutGuids": true,
+        "iconDisplay": 2,
         "inputParameters": [
             {
                 "name": "X",


### PR DESCRIPTION
Hey @gonzalocasas, thanks for this handy tool! I wanted a functionality to set the component icon mode so here it is 😄 

Strangely, the [IconDisplayMode enum](https://developer.rhino3d.com/api/grasshopper/html/T_Grasshopper_Kernel_GH_IconDisplayMode.htm) doesn't seem to match up with the GH xml setting - icon is 2 and name is 1 🤷 