### PR TITLE
Adding pointcloud datatype to cpy gh-componentizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Supports a small set of templated variables that can be used in code:
       string values (their respective Guids are not listed here for readability):
       `none`, `ghdoc`, `float`, `bool`, `int`, `complex`, `str`, `datetime`, `guid`,
       `color`, `point`, `vector`, `plane`, `interval`, `uvinterval`, `box`, `transform`,
-      `line`, `circle`, `arc`, `polyline`, `rectangle`, `curve`, `mesh`, `surface`, `subd`, `brep`, `geometrybase`.
+      `line`, `circle`, `arc`, `polyline`, `rectangle`, `curve`, `mesh`, `surface`, `subd`, `brep`, `pointcloud", `geometrybase`.
     * `reverse`: **(optional)** Defines whether data inside the parameter is reversed. Defaults to `False`.
     * `simplify`: **(optional)** Defines whether data inside the parameter is simplified. Defaults to `False`.
     * `flatten`: **(optional)** Defines whether data inside the parameter is flattened. Mutually exclusive with `graft`. Defaults to `False`.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Supports a small set of templated variables that can be used in code:
       string values (their respective Guids are not listed here for readability):
       `none`, `ghdoc`, `float`, `bool`, `int`, `complex`, `str`, `datetime`, `guid`,
       `color`, `point`, `vector`, `plane`, `interval`, `uvinterval`, `box`, `transform`,
-      `line`, `circle`, `arc`, `polyline`, `rectangle`, `curve`, `mesh`, `surface`, `subd`, `brep`, `pointcloud", `geometrybase`.
+      `line`, `circle`, `arc`, `polyline`, `rectangle`, `curve`, `mesh`, `surface`, `subd`, `brep`, `pointcloud`, `geometrybase`.
     * `reverse`: **(optional)** Defines whether data inside the parameter is reversed. Defaults to `False`.
     * `simplify`: **(optional)** Defines whether data inside the parameter is simplified. Defaults to `False`.
     * `flatten`: **(optional)** Defines whether data inside the parameter is flattened. Mutually exclusive with `graft`. Defaults to `False`.

--- a/componentize_cpy.py
+++ b/componentize_cpy.py
@@ -48,6 +48,7 @@ TYPES_MAP = dict(
     surface="f4070a37-c822-410f-9057-100d2e22a22d",
     subd="20f4ca9c-6c90-4fd6-ba8a-5bf9ca79db08",
     brep="2ceb0405-fdfe-403d-a4d6-8786da45fb9d",
+    pointcloud="d73c9fb0-365d-458f-9fb5-f4141399311f",
     geometrybase="c37956f4-d39c-49c7-af71-1e87f8031b26"
 )
 


### PR DESCRIPTION
Hello! ✋ 

This is a very tiny one but we are working on a point cloud plug-in and we were missing the point cloud datatype in the cps parser. This PR adds the corresponding pointcloud's GUID to the dictionary in the `componentize_cpy.py`!

Thanks! ☁️ 

